### PR TITLE
Update Sal.munki.recipe

### DIFF
--- a/Sal/Sal.munki.recipe
+++ b/Sal/Sal.munki.recipe
@@ -67,6 +67,7 @@
                     <string>/usr/local/munki/postflight.d/sal-postflight</string>
                     <string>/usr/local/munki/preflight.d/sal-preflight</string>
                     <string>/usr/local/sal/bin/sal-submit</string>
+                    <string>/usr/local/sal/Python.framework/Versions/Current/lib/python3.9/site-packages/sal/version.py</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
I found that my sal wasn't updating between 4.2.1 and 4.5.0 because the files that the installs array was referencing didn't change. This will allow any change to the `version.py` be recognized as a sufficient change, unfortunately it does tie it to python3.9 which i don't know how to avoid as of now. 